### PR TITLE
Allow a role user to provide their own config template

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ consul_template_archive_file: "consul-template_{{ consul_template_version }}_lin
 consul_template_download_url: "https://github.com/hashicorp/consul-template/releases/download/v{{ consul_template_version }}/{{ consul_template_archive_file }}"
 consul_template_binary: consul-template
 consul_template_home: /opt/consul-template
+consul_template_config_file_template: consul-template.cfg.j2
 consul_template_config_file: consul-template.cfg
 consul_template_log_file: /var/log/consul-template
 consul_template_log_level: "INFO"
@@ -23,9 +24,25 @@ consul_template_use_upstart: false
 Example Playbook Role Usage
 ----------------
 
+## Simple setup
+
+Install and run consul-template using Upstart with a barebones config file that contains no template configuration.
+
 ```
 roles:
-    - { role: consul-template, consul_template_use_upstart: true }
+    - { role: consul-template,
+        consul_template_use_upstart: true }
+```
+
+## Use your own config file
+
+Provide your own configuration file for consul-template.
+
+```
+roles:
+    - { role: consul-template,
+        consul_template_config_file_template: "{{ playbook_dir }}/files/consul-template.cfg.j2"
+        consul_template_use_upstart: true }
 ```
 
 License
@@ -38,3 +55,9 @@ Author Information
 
 Grig Gheorghiu
 http://agiletesting.blogspot.com
+
+Contributors
+------------
+
+Travis Truman
+https://github.com/trumant

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ consul_template_archive_file: "{{ consul_template_release }}.tar.gz"
 consul_template_download_url: "https://github.com/hashicorp/consul-template/releases/download/v{{ consul_template_version }}/{{ consul_template_archive_file }}"
 consul_template_binary: consul-template
 consul_template_home: /opt/consul-template
+consul_template_config_file_template: consul-template.cfg.j2
 consul_template_config_file: consul-template.cfg
 consul_template_log_file: /var/log/consul-template
 consul_template_log_level: "INFO"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -66,6 +66,6 @@
 
 - name: consul-template config file
   template: >
-    src=consul-template.cfg.j2
+    src={{ consul_template_config_file_template }}
     dest={{ consul_template_home }}/config/{{ consul_template_config_file }}
     mode=0755


### PR DESCRIPTION
This is the quick and easy way to allow role consumers to specify their own config without attempting to create and document a bunch of consul_template_* variables that would drive internal templating of the config.