### PR TITLE
Make it work remotely

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,6 @@ Contributors
 
 Travis Truman
 https://github.com/trumant
+
+Marc Abramowitz
+https://github.com/msabramo

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -25,14 +25,14 @@
   get_url:
     url: "{{ consul_template_download_url }}"
     dest: "/tmp"
+  delegate_to: localhost
 
 - name: unzip the downloaded package
   unarchive:
     src: "/tmp/{{ consul_template_archive_file }}"
     dest: "/tmp"
-    owner: "root"
-    group: "root"
     creates: "/tmp/{{ consul_template_release }}/{{ consul_template_binary }}"
+  delegate_to: localhost
 
 - name: copy consul-template binary into place
   copy:


### PR DESCRIPTION
As is, this role wasn't working for provisioning a node that is not the
node running the Ansible playbook. This is because it is relying on the
`unarchive` and `copy` modules, which both assume by default that you're
getting the source file from the local machine (you can change this
with the `unarchive` module by specifying `copy=no`; I don't see a way
of changing this behavior with the `copy` module).

I think your Test Kitchen tests weren't catching this because Test Kitchen
seems to copy the Ansible stuff to the remote host and then run
`ansible-playbook` against `localhost` (I note that all the plays that
are executed have `<localhost>` in the output).

I made this work on remote hosts by having the `get_url` and `unarchive`
tasks execute on `localhost`, so that the `"copy consul-template binary
into place"` task can copy files from `localhost`. This is also more
efficient, because if you're provisioning a number of hosts, you only
have to download and unarchive once, whereas the old way would do this
on every remote host.