### PR TITLE
Conditional package install

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: Grig Gheorghiu
-  description: 
+  description:
   license: license (Apache)
   min_ansible_version: 1.2
   platforms:
@@ -24,7 +24,10 @@ galaxy_info:
   #  - lenny
   #  - squeeze
   #  - wheezy
-  #
+  - name: EL
+    versions:
+    - 6
+    - 7
   categories:
   - cloud
   - cloud:ec2

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -3,13 +3,23 @@
   apt: >
     update_cache=yes
     cache_valid_time=3600
+  when: ansible_os_family == "Debian"
 
-- name: install deps
+- name: install deps (Debian)
   apt: >
     pkg={{item}}
     state=installed
   with_items:
     - unzip
+  when: ansible_os_family == "Debian"
+
+- name: install deps (RedHat)
+  yum: >
+    pkg={{ item }}
+    state=installed
+  with_items:
+    - unzip
+  when: ansible_os_family == "RedHat"
 
 - name: create consul-template directory structure
   file: >
@@ -84,4 +94,3 @@
   with_items: consul_template_template_files
   when: consul_template_template_files
   notify: restart consul-template
-


### PR DESCRIPTION
Use `apt` as the package manager to install unzip in debian-based systems and use `yum` in RedHat derivatives. Closes #10.

Note: with Ansible 2.0 this won't be needed as there is a new [package module](http://docs.ansible.com/ansible/package_module.html) to abstract all this.