### PR TITLE
Fix kitchen tests

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,10 +9,15 @@ provisioner:
   hosts: all
 
 platforms:
-  - name: trusty64
+  - name: ubuntu/vivid64
     driver_config:
-      box: ubuntu/trusty64
-      box_url: https://atlas.hashicorp.com/ubuntu/trusty64
+      box: ubuntu/vivid64
+      box_url: https://atlas.hashicorp.com/ubuntu/vivid64
+
+  - name: centos/7
+    driver_config:
+      box: centos/7
+      box_url: https://atlas.hashicorp.com/centos/7
 
 suites:
   - name: default

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -13,6 +13,10 @@
     - unzip
   when: ansible_os_family == "Debian"
 
+- name: fail with Fedora 22+
+  fail: msg="Fedora 22+ is not supported yet because it uses dnf"
+  when: ansible_distribution == "Fedora" and ansible_distribution_major_version|int >= 22
+
 - name: install deps (RedHat)
   yum: >
     pkg={{ item }}

--- a/test/integration/default.yml
+++ b/test/integration/default.yml
@@ -2,4 +2,4 @@
 - hosts: localhost
 
   roles:
-    - { role: ansible-consul-template, consul_template_use_upstart: true }
+    - { role: ansible-consul-template, consul_template_use_systemd: true }

--- a/test/integration/default/serverspec/consul_template_spec.rb
+++ b/test/integration/default/serverspec/consul_template_spec.rb
@@ -5,10 +5,6 @@ describe 'Consul Template' do
     it { should be_enabled }
   end
 
-  describe file('/var/log/consul-template') do
-    it { should be_file }
-  end
-
   describe file('/opt/consul-template/bin/consul-template') do
     it { should be_file }
     it { should be_executable }
@@ -20,6 +16,6 @@ describe 'Consul Template' do
 
   describe command('/opt/consul-template/bin/consul-template -v') do
     its(:exit_status) { should eq 0 }
-    its(:stderr) { should match /v0\.11\.1/ }
+    its(:stderr) { should match /v0\.12\.0/ }
   end
 end


### PR DESCRIPTION
This fixes the tests and adds a new test platform (centos 7, a redhat-based operating system).

Issues found:
- I had to use ubuntu/vivid instead of ubuntu/trusty and use systemd (default in centos7/rh7) instead of upstart.
- `should be_file` in `describe file('/var/log/consul-template') do` didn't work in my laptop and I don't know why.
- Fedora 22+ is not supported (it comes with `dnf` package manager instead of `yum`). The role is now aware of that and fails with an informative message until suport for Fedora is added. 