### PR TITLE
Add variable for Consul port

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ consul_template_config_file: consul-template.cfg
 consul_template_log_file: /var/log/consul-template
 consul_template_log_level: "INFO"
 consul_template_consul_server: "127.0.0.1"
+consul_template_consul_port: "8500"
 consul_template_use_systemd: false
 consul_template_use_upstart: false
 consul_template_template_files: # Copies your templates

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,7 @@ consul_template_config_file: consul-template.cfg
 consul_template_log_file: /var/log/consul-template
 consul_template_log_level: "INFO"
 consul_template_consul_server: "127.0.0.1"
+consul_template_consul_port: "8500"
 consul_template_use_systemd: false
 consul_template_use_upstart: false
 consul_template_template_files: [] # see readme for usage

--- a/templates/consul-template.cfg.j2
+++ b/templates/consul-template.cfg.j2
@@ -1,4 +1,4 @@
-consul = "{{ consul_template_consul_server }}:8500"
+consul = "{{ consul_template_consul_server }}:{{ consul_template_consul_port }}"
 {% if consul_template_templates %}
 {% for template in consul_template_templates %}
 


### PR DESCRIPTION
Adds the `consul_template_consul_port` for defining a non-standard Consul port.