### PR TITLE
fixed sudo deprecation warning msg

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,6 +16,6 @@ Vagrant.configure(2) do |config|
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "test.yml"
     ansible.verbose = 'vv'
-    ansible.sudo = true
+    ansible.become = true
   end
 end

--- a/test.yml
+++ b/test.yml
@@ -1,7 +1,7 @@
 ---
 
 - hosts: all
-  sudo: true
+  become: yes
   roles:
     - savagegus.consul
     - ansible-consul-template


### PR DESCRIPTION
I kept getting this message:
```
[DEPRECATION WARNING]: Instead of sudo/sudo_user, use become/become_user and make 
sure become_method is 'sudo' (default). This feature will be removed in a future 
release. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
```
So I fixed it.