### PR TITLE
fixed testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .bundle
 .vagrant
 bin/
+roles

--- a/README.md
+++ b/README.md
@@ -53,6 +53,22 @@ roles:
         consul_template_use_upstart: true }
 ```
 
+Testing
+-------
+
+To test the playbook locally, first install the required dependencies locally.
+
+```
+$ ansible-galaxy install --role-file=requirements.yml --roles-path=roles --force
+```
+
+Then run vagrant.
+
+```
+vagrant up
+vagrant provision
+```
+
 License
 -------
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ Then run vagrant.
 
 ```
 vagrant up
-vagrant provision
 ```
 
 License

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,10 +12,11 @@ Vagrant.configure(2) do |config|
   #   # Customize the amount of memory on the VM:
   #   vb.memory = "1024"
   # end
-  
+
+
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "test.yml"
     ansible.verbose = 'vv'
-    ansible.become = true
+    ansible.sudo = true
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,10 +13,12 @@ Vagrant.configure(2) do |config|
   #   vb.memory = "1024"
   # end
 
-
-  config.vm.provision "ansible" do |ansible|
-    ansible.playbook = "test.yml"
-    ansible.verbose = 'vv'
-    ansible.sudo = true
+  config.vm.define "test" do |test|
+    test.vm.hostname = "test"
+    test.vm.provision "ansible" do |ansible|
+      ansible.playbook = "test.yml"
+      ansible.verbose = 'vv'
+      ansible.become = true
+    end
   end
 end

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,1 @@
+- src: savagegus.consul


### PR DESCRIPTION
There is a bug when attempting to run the tests.
```
$ vagrant up
Bringing machine 'test' up with 'virtualbox' provider...
There are errors in the configuration of this machine. Please fix
the following errors and try again:

ansible remote provisioner:
* The following settings shouldn't exist: become
```
I created this problem with my last pull request.

This commit fixes that issue and adds documentation to the README file on how to run the tests locally.