### PR TITLE
Updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .vagrant
 bin/
 roles
+meta/.galaxy_install_info


### PR DESCRIPTION
I added meta/.galaxy_install_info to .gitignore so that I could install as a role in a playbook that is a submodule of another repo without having modified untracked content in that repo.