### PR TITLE
Change service state to 'started'

### DIFF
--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -1,4 +1,4 @@
 - service: >
     name=consul-template
-    state=running
+    state=started
     enabled=yes


### PR DESCRIPTION
Fix service idempotency by setting state to 'started' as 'running' is not a valid state according to [this](http://docs.ansible.com/ansible/service_module.html)