### PR TITLE
Feature/j2 template templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ consul_template_template_files: # Copies your templates
     - {src: "template.ctmpl"}
 consul_template_templates: # Defines templates in configuration
     - {name: "template.ctmpl", dest: "/path/on/disk/where/template/will/render", cmd: "optional command to run when the template is updated", perms: 0600, backup: true}
+consul_template_template_templates: # Defines j2 versions of templates to be rendered as consul-template templates
+    - {name: "template.ctmpl.j2", dest: "/path/on/disk/where/template/will/render", cmd: "optional command to run when the template is updated", perms: 0600, backup: true}
 ```
 
 Example Playbook Role Usage

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,3 +16,4 @@ consul_template_use_systemd: false
 consul_template_use_upstart: false
 consul_template_template_files: [] # see readme for usage
 consul_template_templates: [] # - {name: "template.ctmpl", dest: "/path/on/disk/where/template/will/render", cmd: "optional command to run when the template is updated", perms: 0600, backup: false}
+consul_template_template_templates: [] # - {name: "template.ctmpl.j2", dest: "/path/on/disk/where/template/will/render", cmd: "optional command to run when the template is updated", perms: 0600, backup: true}

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -98,3 +98,9 @@
   with_items: consul_template_template_files
   when: consul_template_template_files
   notify: restart consul-template
+
+- name: copy template templates
+  template: src={{ item.src }} dest="{{ consul_template_home }}/templates/{{ item.src | basename | regex_replace('^(.*)\.j2$', '\\1') }}"
+  with_items: consul_template_template_templates
+  when: consul_template_template_templates
+  notify: restart consul-template

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -1,4 +1,4 @@
 - service: >
     name=consul-template
-    state=running
+    state=started
     enabled=yes


### PR DESCRIPTION
* Add feature - template templates can be rendered via j2 templates

This functionality is useful when you want to take advantage of jinja2 templating to create `.ctmpl` files for a truly dynamic solution.  Caution must be taken in `.ctmpl.j2` files to escape the expression delimiters intended for downstream, like `{{ '{{' }}` and `{{ '}}' }}`