### PR TITLE
Restart consul-template with systemd

### DIFF
--- a/templates/consul-template.service.systemd.j2
+++ b/templates/consul-template.service.systemd.j2
@@ -8,5 +8,8 @@ ExecStart=/bin/sh -c "{{ consul_template_home }}/bin/{{ consul_template_binary }
 ExecStart=/bin/sh -c "{{ consul_template_home }}/bin/{{ consul_template_binary }}  -config={{ consul_template_home }}/config/{{ consul_template_config_file }} >> {{ consul_template_log_file }} 2>&1"
 {% endif %}
 
+Restart=always
+RestartSec=5
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Add systemd flags (Restart, RestartSec) to restart the consul-template process when it fails.
In many scenarios it is important to keep consul-template running even after something goes wrong.