### PR TITLE
Add missing quotes in tasks/install.yml

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -94,8 +94,8 @@
     mode=0755
 
 - name: copy template files
-  copy: src={{ item.src }} dest="{{ consul_template_home }}/templates/{{ item.src | basename }}"
-  with_items: consul_template_template_files
+  copy: src="{{ item.src }}" dest="{{ consul_template_home }}/templates/{{ item.src | basename }}"
+  with_items: "{{ consul_template_template_files }}"
   when: consul_template_template_files
   notify: restart consul-template
 


### PR DESCRIPTION
@griggheo thank you for this playbook.

Adding missing quotes around few instructions, at least for 2.2.1.0 it complains and does not interpret array as expected.