### PR TITLE
Allow overriding of systemd and Upstart service template files

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ consul_template_consul_port: "8500"
 consul_template_use_systemd: false
 consul_template_use_upstart: false
 consul_template_use_initd: false
+consul_template_systemd_template: "consul-template.service.systemd.j2"
+consul_template_upstart_template: "consul-template.service.upstart.j2"
 consul_template_initd_template: "consul-template.initd.sh.j2"
 consul_template_wait: <undefined>
 consul_template_template_files: # Copies your templates

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,8 @@ consul_template_consul_port: "8500"
 consul_template_use_systemd: false
 consul_template_use_upstart: false
 consul_template_use_initd: false
+consul_template_systemd_template: "consul-template.service.systemd.j2"
+consul_template_upstart_template: "consul-template.service.upstart.j2"
 consul_template_initd_template: "consul-template.initd.sh.j2"
 consul_template_template_files: [] # see readme for usage
 consul_template_templates: [] # - {name: "template.ctmpl", dest: "/path/on/disk/where/template/will/render", cmd: "optional command to run when the template is updated", perms: 0600, backup: false}

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -67,21 +67,21 @@
 
 - name: copy consul-template systemd service configuration
   template: >
-    src=consul-template.service.systemd.j2
+    src={{ consul_template_systemd_template }}
     dest=/etc/systemd/system/consul-template.service
     mode=0755
   when: consul_template_use_systemd
 
 - name: copy consul-template upstart service configuration
   template: >
-    src=consul-template.service.upstart.j2
+    src={{ consul_template_upstart_template }}
     dest=/etc/init/consul-template.conf
     mode=0755
   when: consul_template_use_upstart
 
 - name: copy consul-template init.d script
   template: >
-    src={{consul_template_initd_template}}
+    src={{ consul_template_initd_template }}
     dest=/etc/init.d/consul-template
     owner=root
     group=root


### PR DESCRIPTION
Currently, the initd template file can be overridden by a variable. This change adds the same functionality for systemd and Upstart