### PR TITLE
fixup consul-template-template-templates documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ consul_template_initd_template: "consul-template.initd.sh.j2"
 consul_template_wait: <undefined>
 consul_template_template_files: # Copies your templates
     - {src: "template.ctmpl"}
+consul_template_template_templates: # Generates and copies your consul-template templates from ansible j2 templates.
+    - {src: "template.ctmpl.j2"}
 consul_template_templates: # Defines templates in configuration
     - {name: "template.ctmpl", dest: "/path/on/disk/where/template/will/render", cmd: "optional command to run when the template is updated", perms: 0600, backup: true, wait: "2s"}
-consul_template_template_templates: # Defines j2 versions of templates to be rendered as consul-template templates
-    - {name: "template.ctmpl.j2", dest: "/path/on/disk/where/template/will/render", cmd: "optional command to run when the template is updated", perms: 0600, backup: true}
 ```
 
 Example Playbook Role Usage

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,6 @@ consul_template_use_systemd: false
 consul_template_use_upstart: false
 consul_template_use_initd: false
 consul_template_initd_template: "consul-template.initd.sh.j2"
-consul_template_template_files: [] # see readme for usage
+consul_template_template_files: [] # - {src: "template.ctmpl"} (see readme for usage)
+consul_template_template_templates: [] # - {src: "template.ctmpl.j2"}
 consul_template_templates: [] # - {name: "template.ctmpl", dest: "/path/on/disk/where/template/will/render", cmd: "optional command to run when the template is updated", perms: 0600, backup: false}
-consul_template_template_templates: [] # - {name: "template.ctmpl.j2", dest: "/path/on/disk/where/template/will/render", cmd: "optional command to run when the template is updated", perms: 0600, backup: true}


### PR DESCRIPTION
Fixing readme uses and ordering of
consul_template_template_templates. This was rather
confusing for me to see so many "template" words in a row, and the
readme for its usage should be fixed.

It makes the most sense to have this reordered straight under
consul_template_template_files as both are tasks for creating
consul-template templates.