### PR TITLE
Allow to change the destination filename when using a templated template

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -109,7 +109,7 @@
   notify: restart consul-template
 
 - name: copy template templates
-  template: src={{ item.src }} dest="{{ consul_template_home }}/templates/{{ item.src | basename | regex_replace('^(.*)\.j2$', '\\1') }}"
+  template: src={{ item.src }} dest="{{ consul_template_home }}/templates/{{ item.dest if item.dest is defined else item.src | basename | regex_replace('^(.*)\.j2$', '\\1') }}"
   with_items: "{{ consul_template_template_templates | default([]) }}"
   when: consul_template_template_templates
   notify: restart consul-template


### PR DESCRIPTION
Why :
When you use templates of templates, you may like to inject data in the template using the same template multiple times. 
This is easily done, but as the destination keep the same name as the source file, the different files will all be overwritten. 
This simple patch allows to override the destination file name without interfering with the existing installations.