### PR TITLE
Fix install deps

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -8,7 +8,7 @@
 - name: install deps (Debian)
   apt: >
     pkg={{item}}
-    state=installed
+    state=present
   with_items:
     - unzip
   when: ansible_os_family == "Debian"
@@ -20,7 +20,7 @@
 - name: install deps (RedHat)
   yum: >
     pkg={{ item }}
-    state=installed
+    state=present
   with_items:
     - unzip
   when: ansible_os_family == "RedHat"


### PR DESCRIPTION
```
✗ ansible --version
ansible 2.9.6
```

```sh
TASK [griggheo.consul-template : install deps (Debian)] ************************************************************************************************************************************************************
failed: [frontend.consul] (item=['unzip']) => {"ansible_loop_var": "item", "changed": false, "item": ["unzip"], "msg": "value of state must be one of: absent, build-dep, fixed, latest, present, got: installed"}
```