### PR TITLE
Do not read the filesystem when check mode is on

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -49,10 +49,12 @@
     group: "root"
     copy: False
     creates: "{{ consul_template_staging_area }}/{{ consul_template_binary }}"
+  when: not ansible_check_mode
 
 - name: copy consul-template binary into place
   command: cp {{ consul_template_staging_area }}/{{ consul_template_binary }} {{ consul_template_home }}/bin/{{ consul_template_binary }}
     creates={{ consul_template_home }}/bin/{{ consul_template_binary }}
+  when: not ansible_check_mode
 
 - name: Update consul-template permissions
   file:


### PR DESCRIPTION
Ansible can run check mode, however, when it tries to read a file that should have been previously downloaded it fails and check mode cannote continue. 
This PR solve this problem by skipping the task  in check mode.

