### PR TITLE
Fix consul-template.cfg broken newlines

### DIFF
--- a/templates/consul-template.cfg.j2
+++ b/templates/consul-template.cfg.j2
@@ -1,13 +1,14 @@
+#jinja2: trim_blocks:False
 consul = "{{ consul_template_consul_server }}:{{ consul_template_consul_port }}"
-{% if consul_template_log_level %}
+{% if consul_template_log_level -%}
 log_level = "{{consul_template_log_level}}"
-{% endif %}
-{% if consul_template_wait is defined %}
+{% endif -%}
+{% if consul_template_wait is defined -%}
 wait = "{{consul_template_wait}}"
-{% endif %}
-{% if not consul_template_use_config_dir %}
-{% if consul_template_templates %}
-{% for template in consul_template_templates %}
+{% endif -%}
+{% if not consul_template_use_config_dir -%}
+{% if consul_template_templates -%}
+{% for template in consul_template_templates -%}
 template {
   source = "{{ consul_template_home }}/templates/{{ template.name }}"
   destination = "{{ template.dest }}"
@@ -15,6 +16,6 @@ template {
   {% if template.perms is defined %}perms = {{ template.perms }}{% endif %}
   {% if template.backup is defined %}backup = {{ template.backup|lower }}{% endif %}
   {% if template.wait is defined %}wait = {{ template.wait|lower }}{% endif %}
-}{% endfor %}
-{% endif %}
-{% endif %}
+}{% endfor -%}
+{% endif -%}
+{% endif -%}


### PR DESCRIPTION
Without `#jinja2: trim_blocks:False` the resulting file is invalid,
example:

```
consul = "127.0.0.1:8500"
log_level = "INFO"
template {
  source = "/opt/consul-template/templates/haproxy.ctmpl"
  destination = "/etc/haproxy/haproxy.cfg" command = "systemctl reload haproxy.service" perms = 0600 backup = truewait = 2s}
```

Hence making consul-template