### PR TITLE
fix: signal behaviour for systemd

### DIFF
--- a/templates/consul-template.service.systemd.j2
+++ b/templates/consul-template.service.systemd.j2
@@ -1,12 +1,18 @@
 [Unit]
 Description=consul-template
+Requires=network-online.target
+After=network-online.target
 
 [Service]
 {% if consul_template_use_config_dir %}
-ExecStart=/bin/sh -c "{{ consul_template_home }}/bin/{{ consul_template_binary }}  -config={{ consul_template_home }}/config/ >> {{ consul_template_log_file }} 2>&1"
+ExecStart={{ consul_template_home }}/bin/{{ consul_template_binary }} -config={{ consul_template_home }}/config/"
 {% else %}
-ExecStart=/bin/sh -c "{{ consul_template_home }}/bin/{{ consul_template_binary }}  -config={{ consul_template_home }}/config/{{ consul_template_config_file }} >> {{ consul_template_log_file }} 2>&1"
+ExecStart={{ consul_template_home }}/bin/{{ consul_template_binary }} -config={{ consul_template_home }}/config/{{ consul_template_config_file }}
 {% endif %}
+Restart=on-failure
+
+KillSignal=SIGINT
+ExecReload=kill -HUP $MAINPID
 
 Restart=always
 RestartSec=5


### PR DESCRIPTION
### What
The systemd service file resulted in slow restarts of the service (30s+ for one service, I run this on many hosts)

### Why
Wrapping consul-template in /bin/sh isn't appropriate here, if you're using it for output redirection purposes consul-template and/or systemd both have support for sinking your logs somewhere.

If it's for signal handling purposes I've addressed that by relying on ssytemd primitives to ensure the correct signals get passed to consul-template for reload and stop/restart purposes.